### PR TITLE
Various improvements and performance gains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 out
+*.vsix

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Run your Jasmine tests using the
 * `jasmineExplorer.config`: The location of the Jasmine config file (relative to the workspace folder) (default: `spec/support/jasmine.json`)
 * `jasmineExplorer.env`: Environment variables to be set when running the tests
 * `jasmineExplorer.nodePath`: The path to the node executable to use. By default it will attempt to find it on your PATH, if it can't find it or if this option is set to `null`, it will use the one shipped with VS Code
+* `jasmineExplorer.debuggerPort`: A port for running the debug sessions, (default: `9229`)
+* `jasmineExplorer.breakOnFirstLine`: Setting to true injects a breakpoint at the first line after your test, (default: `false`)
 * `testExplorer.codeLens`: Show a CodeLens above each test or suite for running or debugging the tests
 * `testExplorer.gutterDecoration`: Show the state of each test in the editor using Gutter Decorations
 * `testExplorer.onStart`: Retire or reset all test states whenever a test run is started

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-jasmine-test-adapter",
-  "version": "0.3.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,12 @@
           ],
           "default": "default",
           "scope": "resource"
+        },
+        "jasmineExplorer.breakOnFirstLine": {
+          "description": "when debugging, inject a breakpoint at the 1st line of the 1st run test",
+          "type": "boolean",
+          "default": false,
+          "scope": "resource"
         }
       }
     }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -303,7 +303,6 @@ export class JasmineAdapter implements TestAdapter {
 
 		const processEnv = process.env;
 		const configEnv: { [prop: string]: any } = adapterConfig.get('env') || {};
-		const node: string | undefined = adapterConfig.get('node');
 		const breakOnFirstLine: boolean = adapterConfig.get('breakOnFirstLine') || false;
 		const env = { ...processEnv };
 
@@ -339,7 +338,11 @@ interface LoadedConfig {
 	specDir: string;
 	testFileGlobs: IMinimatch[];
 	testFiles: string[];
+<<<<<<< 3632d366cd498fc6b8a53c652be9d533df57a03b
 	nodePath: string | undefined;
+=======
+	debuggerPort: number;
+>>>>>>> Use attaching the debugger instead of the session.
 	env: { [prop: string]: any };
 	debuggerPort: number;
 	breakOnFirstLine: boolean;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -113,7 +113,7 @@ export class JasmineAdapter implements TestAdapter {
 		});
 		
 		function findFile(suite: { file: string | undefined, children: any[] }): string | undefined {
-			if (!suite.file) {
+			if (!suite.file && suite.children) {
 				for(const child of suite.children) {
 					const file = findFile(child);
 					if (file) { return file; }
@@ -127,7 +127,7 @@ export class JasmineAdapter implements TestAdapter {
 		const suitesByFiles = suites.reduce((memo, suite) => {
 			const file = findFile(suite);
 			if (!file) {
-				throw new Error(`Unable to find the file in suite ${suite.label}` );
+				return memo;
 			}
 			const fileSuite = memo[file] ||  {
 				type: 'suite',

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -83,40 +83,69 @@ export class JasmineAdapter implements TestAdapter {
 			label: 'Jasmine',
 			children: []
 		}
+		const suites: any[] = [];
 
-		for (const testFile of config.testFiles) {
+		await new Promise<JasmineTestSuiteInfo | undefined>(resolve => {
 
-			let testSuiteInfo = await new Promise<JasmineTestSuiteInfo | undefined>(resolve => {
+			const args = [ config.configFilePath ];
+			const childProcess = fork(
+				require.resolve('./worker/loadTests.js'),
+				args,
+				{
+					cwd: this.workspaceFolder.uri.fsPath,
+					execPath: config.nodePath,
+					env: config.env,
+					execArgv: []
+				}
+			);
 
-				const args = [ config.configFilePath, testFile ];
-				let received: TestSuiteInfo | undefined;
-
-				const childProcess = fork(
-					require.resolve('./worker/loadTests.js'),
-					args,
-					{
-						cwd: this.workspaceFolder.uri.fsPath,
-						env: config.env,
-						execPath: config.nodePath,
-						execArgv: []
-					}
-				);
-
-				childProcess.on('message', msg => received = msg);
-
-				childProcess.on('exit', () => resolve(received));
+			childProcess.on('message', (msg) => {
+				suites.push(msg);
 			});
 
-			if (testSuiteInfo !== undefined) {
-
-				testSuiteInfo.label = testFile.startsWith(config.specDir) ? testFile.substr(config.specDir.length) : testFile
-				testSuiteInfo.isFileSuite = true;
-
-				rootSuite.children.push(testSuiteInfo);
+			childProcess.on('exit', (exitVal) => {
+				resolve();
+			});
+		});
+		
+		function findFile(suite: { file: string | undefined, children: any[] }): string | undefined {
+			if (!suite.file) {
+				for(const child of suite.children) {
+					const file = findFile(child);
+					if (file) { return file; }
+				}
+			} else {
+				return suite.file;
 			}
+			return undefined;
 		}
 
+		const suitesByFiles = suites.reduce((memo, suite) => {
+			const file = findFile(suite);
+			if (!file) {
+				throw new Error(`Unable to find the file in suite ${suite.label}` );
+			}
+			const fileSuite = memo[file] ||  {
+				type: 'suite',
+				id: file,
+				file: file,
+				label: file.startsWith(config.specDir) ? file.substr(config.specDir.length) : file,
+				children: [],
+				isFileSuite: true,
+			}
+			fileSuite.children.push(suite);
+			memo[file] = fileSuite;
+			return memo;
+		}, {});
+
+		Object.keys(suitesByFiles).forEach((file) => {
+			rootSuite.children.push(suitesByFiles[file]);
+		});
+
 		if (rootSuite.children.length > 0) {
+			rootSuite.children.sort((a, b) => {
+				return a.id.toLowerCase() < b.id.toLowerCase() ? -1 : 1;
+			});
 			return rootSuite;
 		} else {
 			return undefined;
@@ -131,13 +160,15 @@ export class JasmineAdapter implements TestAdapter {
 		let tests: string[] = [];
 		this.collectTests(info, tests);
 
-		await new Promise<void>((resolve) => {
-
-			const args = [ config.configFilePath ];
-			if (tests) {
-				args.push(JSON.stringify(tests));
+		const args = [ config.configFilePath ];
+		if (tests) {
+			args.push(JSON.stringify(tests));
+			if (info.file) {
+				args.push(info.file);
 			}
+		}
 
+		return new Promise<void>((resolve) => {
 			this.runningTestProcess = fork(
 				require.resolve('./worker/runTests.js'),
 				args,
@@ -161,8 +192,22 @@ export class JasmineAdapter implements TestAdapter {
 	}
 
 	async debug(info: JasmineTestSuiteInfo | TestInfo): Promise<void> {
+		if (!this.config) {
+			return;
+		}
 
-		if (!this.config) return;
+		let currentSession: vscode.DebugSession | undefined; 
+		// Add a breakpoint on the 1st line of the debugger
+		if (this.config.breakOnFirstLine) {
+			const fileURI = vscode.Uri.file(info.file!);
+			const brekpoint = new vscode.SourceBreakpoint(new vscode.Location(fileURI, new vscode.Position(info.line! + 1, 0)))
+			vscode.debug.addBreakpoints([brekpoint]);
+			vscode.debug.onDidTerminateDebugSession((session) => {
+				if (currentSession != session) { return; }
+				vscode.debug.removeBreakpoints([brekpoint]);
+			});
+		}
+
 		const promise = this.run(info,  [`--inspect-brk=${this.config.debuggerPort}`]);
 		if (!promise || !this.runningTestProcess) {
 			return;
@@ -178,7 +223,8 @@ export class JasmineAdapter implements TestAdapter {
 			stopOnEntry: false,
 		});
 
-		const currentSession = vscode.debug.activeDebugSession;
+		currentSession = vscode.debug.activeDebugSession;
+
 		// Kill the process to ensure we're good once the de
 		vscode.debug.onDidTerminateDebugSession((session) => {
 			if (currentSession != session) { return; }
@@ -239,7 +285,8 @@ export class JasmineAdapter implements TestAdapter {
 
 		const processEnv = process.env;
 		const configEnv: { [prop: string]: any } = adapterConfig.get('env') || {};
-
+		const node: string | undefined = adapterConfig.get('node');
+		const breakOnFirstLine: boolean = adapterConfig.get('breakOnFirstLine') || false;
 		const env = { ...processEnv };
 
 		for (const prop in configEnv) {
@@ -255,7 +302,7 @@ export class JasmineAdapter implements TestAdapter {
 			nodePath = this.getNodePath();
 		}
 
-		return { configFilePath, specDir, testFileGlobs, testFiles, env, debuggerPort, nodePath };
+		return { configFilePath, specDir, testFileGlobs, testFiles, env, debuggerPort, nodePath, breakOnFirstLine};
 	}
 
 	private collectTests(info: TestSuiteInfo | TestInfo, tests: string[]): void {
@@ -274,9 +321,10 @@ interface LoadedConfig {
 	specDir: string;
 	testFileGlobs: IMinimatch[];
 	testFiles: string[];
-	debuggerPort: number;
 	nodePath: string | undefined;
 	env: { [prop: string]: any };
+	debuggerPort: number;
+	breakOnFirstLine: boolean;
 }
 
 interface JasmineTestSuiteInfo extends TestSuiteInfo {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -338,13 +338,9 @@ interface LoadedConfig {
 	specDir: string;
 	testFileGlobs: IMinimatch[];
 	testFiles: string[];
-<<<<<<< 3632d366cd498fc6b8a53c652be9d533df57a03b
+	debuggerPort: number;
 	nodePath: string | undefined;
-=======
-	debuggerPort: number;
->>>>>>> Use attaching the debugger instead of the session.
 	env: { [prop: string]: any };
-	debuggerPort: number;
 	breakOnFirstLine: boolean;
 }
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -112,20 +112,8 @@ export class JasmineAdapter implements TestAdapter {
 			});
 		});
 		
-		function findFile(suite: { file: string | undefined, children: any[] }): string | undefined {
-			if (!suite.file && suite.children) {
-				for(const child of suite.children) {
-					const file = findFile(child);
-					if (file) { return file; }
-				}
-			} else {
-				return suite.file;
-			}
-			return undefined;
-		}
-
 		const suitesByFiles = suites.reduce((memo, suite) => {
-			const file = findFile(suite);
+			const file = suite.file;
 			if (!file) {
 				return memo;
 			}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { TestResultsManager } from './testStateManager';
 export async function activate(context: vscode.ExtensionContext) {
 
 	const testExplorerExtension = vscode.extensions.getExtension<TestExplorerExtension>(testExplorerExtensionId);
-
+	const channel = vscode.window.createOutputChannel('Jasmine Tests');
 	if (testExplorerExtension) {
 		
 		if (!testExplorerExtension.isActive) {
@@ -17,7 +17,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 		if (vscode.workspace.workspaceFolders) {
 			for (const workspaceFolder of vscode.workspace.workspaceFolders) {
-				const adapter = new JasmineAdapter(workspaceFolder);
+				const adapter = new JasmineAdapter(workspaceFolder, channel);
 				const resultsManager = new TestResultsManager(workspaceFolder.uri.fsPath, context);
 				adapter.testStates((event) => {
 					resultsManager.handle(event as TestEvent)
@@ -41,7 +41,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 	
 			for (const workspaceFolder of event.added) {
-				const adapter = new JasmineAdapter(workspaceFolder);
+				const adapter = new JasmineAdapter(workspaceFolder, channel);
 				registeredAdapters.set(workspaceFolder, adapter);
 				testExplorerExtension.exports.registerAdapter(adapter);
 			}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,8 +15,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
 		const registeredAdapters = new Map<vscode.WorkspaceFolder, JasmineAdapter>();
 
-		if (vscode.workspace.workspaceFolders) {
-			for (const workspaceFolder of vscode.workspace.workspaceFolders) {
+		function registerWorkspaces(workspaces: vscode.WorkspaceFolder[],
+			testExplorerExtension:vscode.Extension<TestExplorerExtension>,
+			channel: vscode.OutputChannel) {
+			for (const workspaceFolder of workspaces) {
 				const adapter = new JasmineAdapter(workspaceFolder, channel);
 				const resultsManager = new TestResultsManager(workspaceFolder.uri.fsPath, context);
 				adapter.testStates((event) => {
@@ -29,6 +31,12 @@ export async function activate(context: vscode.ExtensionContext) {
 				vscode.languages.registerHoverProvider({ language: 'javascript', scheme: 'file' }, resultsManager);
 			}
 		}
+
+		if (vscode.workspace.workspaceFolders) {
+			registerWorkspaces(vscode.workspace.workspaceFolders, 
+				testExplorerExtension, 
+				channel);
+		}
 	
 		vscode.workspace.onDidChangeWorkspaceFolders((event) => {
 	
@@ -39,12 +47,10 @@ export async function activate(context: vscode.ExtensionContext) {
 					registeredAdapters.delete(workspaceFolder);
 				}
 			}
-	
-			for (const workspaceFolder of event.added) {
-				const adapter = new JasmineAdapter(workspaceFolder, channel);
-				registeredAdapters.set(workspaceFolder, adapter);
-				testExplorerExtension.exports.registerAdapter(adapter);
-			}
+
+			registerWorkspaces(event.added,
+				testExplorerExtension,
+				channel);
 		}, null, context.subscriptions);
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,6 @@ export async function activate(context: vscode.ExtensionContext) {
 				}, null, context.subscriptions);
 				registeredAdapters.set(workspaceFolder, adapter);
 				testExplorerExtension.exports.registerAdapter(adapter);
-
-				// Hover provider
-				vscode.languages.registerHoverProvider({ language: 'javascript', scheme: 'file' }, resultsManager);
 			}
 		}
 

--- a/src/testStateManager.ts
+++ b/src/testStateManager.ts
@@ -1,0 +1,154 @@
+import { TestEvent } from 'vscode-test-adapter-api';
+import * as vscode from 'vscode';
+
+export class TestFailure {
+	message: string;
+	file: string;
+	line: number;
+	column: number;
+	originalEvent: TestEvent;
+
+	static failures(event: TestEvent, worspacePath: string): TestFailure[] {
+		if (!event.message) { return []; }
+		const lines = event.message.split('\n');
+		const errors: TestFailure[] = [];
+		let file: string;
+		let line: number | undefined;
+		let column: number;
+		let message: string | undefined;
+
+		lines.forEach((stackLine) => {
+			if (stackLine.indexOf('Error:') >= 0) {
+				message = stackLine;
+			} else if (stackLine.indexOf(worspacePath) >=0 && message && !line) {
+				const lineURI = stackLine.split('(')[1].split(')')[0]; // remove the parentheses
+				file = lineURI.split(':')[0],
+				line = parseInt(lineURI.split(':')[1]),
+				column = parseInt(lineURI.split(':')[2]),
+				errors.push(new TestFailure(
+					message, file, line, column, event
+				));
+				message = undefined;
+				line = undefined;
+			} 
+		});
+		return errors;
+	}
+
+	constructor(message: string, file: string, line: number, column: number, originalEvent: TestEvent) {
+		this.message = message
+		this.file = file
+		this.line = line
+		this.column = column
+		this.originalEvent = originalEvent
+	}
+}
+
+export class FailuresStore {
+	errors: { [id: string]: {[id: string]: TestFailure} };
+	errorsByName: { [id: string]: TestFailure };
+
+	constructor() {
+		this.errors = {};
+		this.errorsByName = {};
+	}
+
+	public add(failure: TestFailure) {
+		const file = failure.file;
+		const line = failure.line;
+		const test = failure.originalEvent.test;
+		if (!this.errors[file]) {
+			this.errors[file] = {};
+		}
+		this.errors[file][`${line}`] = failure;
+		this.errorsByName[test.toString()] = failure;
+	}
+
+	public remove(fromEvent: TestEvent) {
+		const name = fromEvent.test;
+		const originalError = this.errorsByName[name.toString()];
+		if (!originalError) { return; }
+		if (!this.errors[originalError.file]) { return; }
+		Object.keys(this.errors[originalError.file]).forEach((key) => {
+			const error = this.errors[originalError.file][key];
+			if (error.originalEvent.test === fromEvent.test) {
+				delete this.errors[originalError.file][key];
+			}
+		});
+	}
+	
+	public get(fileName: string, position: number): TestFailure | undefined {
+		if (!this.errors[fileName]) { return; }
+		const errors = this.errors[fileName];
+		return errors[`${position}`];
+	}
+
+	public all(matching: ((test: TestFailure) => boolean) | undefined): TestFailure[] {
+		const initial: TestFailure[] = [];
+		const results: TestFailure[] = Object.keys(this.errors).reduce((memo, key) => {
+			const values = this.errors[key];
+			const failures = Object.keys(values).map((key) => {
+				return values[`${key}`];
+			});
+			return memo.concat(failures);
+		}, initial);
+		
+		if (matching) {
+			return results.filter(matching)
+		}
+		return results;
+	}
+}
+
+export class TestResultsManager {
+	private store: FailuresStore = new FailuresStore()
+	private workspace: string
+	failedTestDecoration = vscode.window.createTextEditorDecorationType({
+		backgroundColor: 'rgba(255,0,0,0.3)',
+		isWholeLine: true,
+		overviewRulerColor: 'rgba(255,0,0,0.3)'
+	})
+
+	constructor(workspace: string, context: vscode.ExtensionContext) {
+		this.workspace = workspace
+		vscode.window.onDidChangeActiveTextEditor((editor) => {
+			this.updateErrorMarkers();
+		}, null, context.subscriptions);
+	}
+
+	public handle(event: TestEvent) {
+		if (event.state === 'running') {
+			this.store.remove(event);
+		}
+		if (event.state === 'passed') {
+			this.store.remove(event);
+		}
+		if (event.state === 'failed' &&
+			event.message) {
+			const failures = TestFailure.failures(event, this.workspace);
+			failures.forEach((error) => this.store.add(error));
+		}
+		this.updateErrorMarkers();
+	}
+
+	private updateErrorMarkers() {
+		const decorations = this.store.all((error) => {
+			return error.file === vscode.window.activeTextEditor!.document.uri.fsPath;
+		}).map((err) => {
+			const options: vscode.DecorationOptions = {
+				range: new vscode.Range(new vscode.Position(err.line-1,0), new vscode.Position(err.line-1, 0)),
+				hoverMessage: err.message
+			};
+			return options;
+		});
+		vscode.window.activeTextEditor!.setDecorations(this.failedTestDecoration, decorations);
+	}
+
+	provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
+		const error = this.store.get(document.fileName, position.line + 1);
+		if (!error) { return; }
+		return new vscode.Hover(`**${error.message}**`, new vscode.Range(position, position));
+	}
+}
+
+

--- a/src/worker/loadTests.ts
+++ b/src/worker/loadTests.ts
@@ -9,6 +9,6 @@ const projectBaseDir = process.argv[3] || process.cwd();
 
 const _jasmine = new Jasmine({ projectBaseDir });
 _jasmine.loadConfigFile(configFile);
-patchJasmine(_jasmine, projectBaseDir);
+const getter = patchJasmine(_jasmine, projectBaseDir);
 _jasmine.execute([], '$^');
-jasmine.getEnv().addReporter(new LoadTestsReporter(sendMessage));
+jasmine.getEnv().addReporter(new LoadTestsReporter(sendMessage, getter));

--- a/src/worker/loadTests.ts
+++ b/src/worker/loadTests.ts
@@ -9,6 +9,6 @@ const projectBaseDir = process.argv[3] || process.cwd();
 
 const _jasmine = new Jasmine({ projectBaseDir });
 _jasmine.loadConfigFile(configFile);
-const getter = patchJasmine(_jasmine, projectBaseDir);
+const getter = patchJasmine(_jasmine);
 _jasmine.execute([], '$^');
 jasmine.getEnv().addReporter(new LoadTestsReporter(sendMessage, getter));

--- a/src/worker/loadTests.ts
+++ b/src/worker/loadTests.ts
@@ -1,12 +1,14 @@
 import Jasmine = require('jasmine');
 import { LoadTestsReporter } from './loadTestsReporter';
+import { patchJasmine } from './loadTestsUtils';
 
 const sendMessage = process.send ? (message: any) => process.send!(message) : () => {};
-
 const configFile = process.argv[2];
-const testFile = process.argv[3];
+// Allow for testing if needed by passing another argument
+const projectBaseDir = process.argv[3] || process.cwd();
 
-const _jasmine = new Jasmine({});
-jasmine.getEnv().addReporter(new LoadTestsReporter(testFile, sendMessage));
+const _jasmine = new Jasmine({ projectBaseDir });
 _jasmine.loadConfigFile(configFile);
-_jasmine.execute([ testFile ], '$^');
+patchJasmine(_jasmine, projectBaseDir);
+_jasmine.execute([], '$^');
+jasmine.getEnv().addReporter(new LoadTestsReporter(sendMessage));

--- a/src/worker/loadTestsReporter.ts
+++ b/src/worker/loadTestsReporter.ts
@@ -1,77 +1,84 @@
-import * as fs from 'fs';
 import { TestSuiteInfo, TestInfo } from "vscode-test-adapter-api";
-import * as RegExpEscape from 'escape-string-regexp';
 
 export class LoadTestsReporter implements jasmine.CustomReporter {
 
 	private readonly rootSuite: TestSuiteInfo;
 	private readonly suiteStack: TestSuiteInfo[];
-	private readonly fileContent: string;
 
 	private get currentSuite(): TestSuiteInfo {
 		return this.suiteStack[this.suiteStack.length - 1];
 	}
 
 	constructor(
-		private readonly testFile: string,
 		private readonly done: (result: TestSuiteInfo) => void
 	) {
 		this.rootSuite = {
 			type: 'suite',
-			id: testFile,
+			id: 'root',
 			label: '',
 			children: [],
-			file: testFile
 		};
 
 		this.suiteStack = [ this.rootSuite ];
-
-		this.fileContent = fs.readFileSync(testFile, 'utf8');
 	}
 
 	suiteStarted(result: jasmine.CustomReporterResult): void {
-
-		const suite: TestSuiteInfo = {
-			type: 'suite',
-			id: result.fullName,
-			label: result.description,
-			file: this.testFile,
-			line: this.findLineContaining(result.description),
-			children: []
-		};
+		// The suite may be a JSON object, from injection
+		// With it's file location
+		const description = result.description;
+		let suite: TestSuiteInfo;
+		try {
+			const { name, location } = JSON.parse(description);
+			suite = {
+				type: 'suite',
+				id: name,
+				label: name,
+				file: location.file,
+				line: location.line,
+				children: []
+			};
+		} catch(e) {
+			suite = {
+				type: 'suite',
+				id: result.fullName,
+				label: description,
+				children: []
+			};
+		}
 
 		this.currentSuite.children.push(suite);
 		this.suiteStack.push(suite);
 	}
 
 	suiteDone(result: jasmine.CustomReporterResult): void {
-		this.suiteStack.pop();
+		const suite = this.suiteStack.pop();
+		// Emit the suite when have been through it completely
+		// This ensure we don't serialize a massive object on done
+		if (suite && this.suiteStack.length <= 1) {
+			this.done(suite);
+		}
 	}
 
 	specDone(result: jasmine.CustomReporterResult): void {
-
+		// Desription is an array as injected before 
+		const description: any[] = result.description as any;
+		const {
+			line,
+			file
+		} = description[1];
 		const test: TestInfo = {
 			type: 'test',
-			id: result.fullName,
-			label: result.description,
-			file: this.testFile,
-			line: this.findLineContaining(result.description)
+			id: result.description[0],
+			label: result.description[0],
+			line: line,
+			file: file,
 		}
-
 		this.currentSuite.children.push(test);
 	}
 
 	jasmineDone(runDetails: jasmine.RunDetails): void {
 		this.sort(this.rootSuite);
 		this.done(this.rootSuite);
-	}
-
-	private findLineContaining(needle: string): number | undefined {
-
-		const index = this.fileContent.search(RegExpEscape(needle));
-		if (index < 0) return undefined;
-
-		return this.fileContent.substr(0, index).split('\n').length - 1;
 	}
 
 	private sort(suite: TestSuiteInfo): void {

--- a/src/worker/loadTestsUtils.ts
+++ b/src/worker/loadTestsUtils.ts
@@ -1,0 +1,60 @@
+import Jasmine = require('jasmine');
+
+export function getStackLineMatching(test: (line: string) => boolean): object {
+	const err = new Error();
+	const stackLines = err.stack!.split('\n');
+	let lastFoundLine;
+	let found;
+	// As long as we have 2 consecutive lines up the stack
+	// in our project, that means the it / describe originate from 
+	// one of the helpers / global variable, walking up ensure
+	// the file location is not where the describe is defined
+	// but where it's called in the code
+	while (!found && stackLines.length > 0) {
+		const line = stackLines.shift()!;
+		if (test(line)) {
+			lastFoundLine = line;
+		} else if (lastFoundLine) {
+			found = lastFoundLine;
+		}
+	}
+
+	// Not found... nothing much we can do
+	if (!found) {
+		return {};
+	}
+
+	const components = found.split(':');
+	const specLine = components[components.length - 2];
+	let file = components[0];
+	if (file.indexOf('(') >= 0) {
+		file = file.split('(')[1]
+	}
+	return {
+		file,
+		line: parseInt(specLine) - 1,
+	}
+}
+
+export function patchJasmine(_jasmine: Jasmine, projectBaseDir: string) {
+	// Monkey patch the it, so we can get the lines
+	const it = _jasmine.env.it;
+	_jasmine.env.it = function(desc, func) {
+		return it.call(this, [desc, getStackLineMatching((line) => {
+			return line.indexOf('Suite.') >= 0 && line.indexOf(projectBaseDir) >= 0;
+		}), func]);
+	}
+
+	// Here we need to inject the description in the name
+	const describe = _jasmine.env.describe;
+	_jasmine.env.describe = function(name, func) {
+		const location = getStackLineMatching((line) => {
+			return line.indexOf(projectBaseDir) >= 0;
+		});
+		const fullName = JSON.stringify({
+			name,
+			location,
+		});
+		return describe.apply(_jasmine.env, [fullName, func]);
+	}
+}

--- a/src/worker/runTests.ts
+++ b/src/worker/runTests.ts
@@ -1,18 +1,24 @@
 import Jasmine = require('jasmine');
 import * as RegExEscape from 'escape-string-regexp';
 import { RunTestsReporter } from './runTestsReporter';
-
 const sendMessage = process.send ? (message: any) => process.send!(message) : () => {};
 
-const configFile = process.argv[2];
 let testsToRun: string[] | undefined;
-if (process.argv.length > 3) {
-	testsToRun = JSON.parse(process.argv[3]);
+let testFiles = [];
+
+const argv = process.argv;
+const configFile = argv[2];
+
+if (argv.length > 3) {
+	testsToRun = JSON.parse(argv[3]);
+}
+
+if (argv.length > 4) {
+	testFiles.push(argv[4]);
 }
 
 const regExp = testsToRun ? testsToRun.map(RegExEscape).join('|') : undefined;
-
-const _jasmine = new Jasmine({});
-jasmine.getEnv().addReporter(new RunTestsReporter(sendMessage, testsToRun));
+const _jasmine = new Jasmine({ baseProjectPath: process.cwd });
 _jasmine.loadConfigFile(configFile);
-_jasmine.execute(undefined, regExp);
+_jasmine.execute(testFiles, regExp);
+_jasmine.addReporter(new RunTestsReporter(sendMessage, testsToRun));

--- a/src/worker/runTests.ts
+++ b/src/worker/runTests.ts
@@ -21,4 +21,4 @@ const regExp = testsToRun ? testsToRun.map(RegExEscape).join('|') : undefined;
 const _jasmine = new Jasmine({ baseProjectPath: process.cwd });
 _jasmine.loadConfigFile(configFile);
 _jasmine.execute(testFiles, regExp);
-_jasmine.addReporter(new RunTestsReporter(sendMessage, testsToRun));
+jasmine.getEnv().addReporter(new RunTestsReporter(sendMessage, testsToRun));

--- a/src/worker/runTestsReporter.ts
+++ b/src/worker/runTestsReporter.ts
@@ -21,14 +21,6 @@ export class RunTestsReporter implements jasmine.CustomReporter {
 		}
 	}
 
-	// Confirmance to jasmine.Report
-	reportRunnerStarting(runner: jasmine.Runner): void {}
-	reportRunnerResults(runner: jasmine.Runner): void {}
-	reportSuiteResults(suite: jasmine.Suite): void {}
-	reportSpecStarting(spec: jasmine.Spec): void {}
-	reportSpecResults(spec: jasmine.Spec): void {}
-	log(str: string): void {}
-
 	specDone(result: jasmine.CustomReporterResult): void {
 		if ((this.testsToReport === undefined) ||
 			(this.testsToReport.indexOf(result.fullName) >= 0)) {

--- a/src/worker/runTestsReporter.ts
+++ b/src/worker/runTestsReporter.ts
@@ -8,13 +8,12 @@ export class RunTestsReporter implements jasmine.CustomReporter {
 	) {}
 
 	specStarted(result: jasmine.CustomReporterResult): void {
-
 		if ((this.testsToReport === undefined) ||
-			(this.testsToReport.indexOf(result.fullName) >= 0)) {
+			(this.testsToReport.indexOf(result.description) >= 0)) {
 
 			const event: TestEvent = {
 				type: 'test',
-				test: result.fullName,
+				test: result.description,
 				state: 'running'
 			};
 	
@@ -22,26 +21,50 @@ export class RunTestsReporter implements jasmine.CustomReporter {
 		}
 	}
 
-	specDone(result: jasmine.CustomReporterResult): void {
+	// Confirmance to jasmine.Report
+	reportRunnerStarting(runner: jasmine.Runner): void {}
+	reportRunnerResults(runner: jasmine.Runner): void {}
+	reportSuiteResults(suite: jasmine.Suite): void {}
+	reportSpecStarting(spec: jasmine.Spec): void {}
+	reportSpecResults(spec: jasmine.Spec): void {}
+	log(str: string): void {}
 
+	specDone(result: jasmine.CustomReporterResult): void {
 		if ((this.testsToReport === undefined) ||
-			(this.testsToReport.indexOf(result.fullName) >= 0)) {
+			(this.testsToReport.indexOf(result.description) >= 0)) {
 
 			let message: string | undefined;
 			if (result.failedExpectations) {
 				message = result.failedExpectations.map(failed => failed.stack).join('\n');
 			}
 
-			const event: TestEvent = {
-				type: 'test',
-				test: result.fullName,
-				state: convertTestState(result.status),
-				message
-			};
+			const state = convertTestState(result.status);
+			let event: TestEvent
+			if (state === 'failed') {
+				const f: FailedTestEvent = {
+					type: 'test',
+					test: result.description,
+					state: convertTestState(result.status),
+					message,
+					failures: result.failedExpectations
+				};
+				event = f;
+			} else {
+				event = {
+					type: 'test',
+					test: result.description,
+					state: convertTestState(result.status),
+					message,
+				};
+			}
 
 			this.sendMessage(event);
 		}
 	}
+}
+
+interface FailedTestEvent extends TestEvent {
+	failures: jasmine.FailedExpectation[] | undefined
 }
 
 function convertTestState(jasmineState: string | undefined): 'passed' | 'failed' | 'skipped' {

--- a/src/worker/runTestsReporter.ts
+++ b/src/worker/runTestsReporter.ts
@@ -9,11 +9,11 @@ export class RunTestsReporter implements jasmine.CustomReporter {
 
 	specStarted(result: jasmine.CustomReporterResult): void {
 		if ((this.testsToReport === undefined) ||
-			(this.testsToReport.indexOf(result.description) >= 0)) {
+			(this.testsToReport.indexOf(result.fullName) >= 0)) {
 
 			const event: TestEvent = {
 				type: 'test',
-				test: result.description,
+				test: result.fullName,
 				state: 'running'
 			};
 	
@@ -31,31 +31,21 @@ export class RunTestsReporter implements jasmine.CustomReporter {
 
 	specDone(result: jasmine.CustomReporterResult): void {
 		if ((this.testsToReport === undefined) ||
-			(this.testsToReport.indexOf(result.description) >= 0)) {
-
+			(this.testsToReport.indexOf(result.fullName) >= 0)) {
 			let message: string | undefined;
 			if (result.failedExpectations) {
 				message = result.failedExpectations.map(failed => failed.stack).join('\n');
 			}
 
 			const state = convertTestState(result.status);
-			let event: TestEvent
+			const event: TestEvent = {
+				type: 'test',
+				test: result.fullName,
+				state: convertTestState(result.status),
+				message,
+			}
 			if (state === 'failed') {
-				const f: FailedTestEvent = {
-					type: 'test',
-					test: result.description,
-					state: convertTestState(result.status),
-					message,
-					failures: result.failedExpectations
-				};
-				event = f;
-			} else {
-				event = {
-					type: 'test',
-					test: result.description,
-					state: convertTestState(result.status),
-					message,
-				};
+				(event as FailedTestEvent).failures = result.failedExpectations
 			}
 
 			this.sendMessage(event);


### PR DESCRIPTION
Hi there! 

So there it is with the current status I am in. There are many things that I've updated:

1. the file lookup algorithm, now leverating stacks and monkey patching, takes 3s to load 1700 tests across 50 files (instead of a minute) with babel-register and a large helper

2. Use the run for both run and debug, debug passes as `--debug-brk` when starting the run and 'attaches the debugger' this work reliably and we have a proper report of the test success / failures

3. Adds breakpoint addition option, this creates a breakpoint on the 1st line of the test, so you can get a coffee and it wil wait for you!

4. Node option: Sometimes, you want a particular version of node, added an option for that!

5. RunTest take an optional file in which the test is located, this speeds up the startup time

6. WIP: Adds FailedTestEvent so we can probalby colorize the bad lines / add gutter on the failing expectations. Let me know.

This is my first vscode extension, thanks again for getting this started, I wanted this for the longest time.