### PR TITLE
Fixes #60

### DIFF
--- a/src/worker/patchJasmine.ts
+++ b/src/worker/patchJasmine.ts
@@ -38,7 +38,8 @@ function findCallLocation(globs: IMinimatch[], functionName: string): Location |
 	const stackFrames = stackTrace.parse(new Error());
 
 	for (const callSite of stackFrames) {
-		if (globs.some(glob => glob.match(callSite.getFileName()))) {
+		const fileName = callSite.getFileName();
+        if (fileName && globs.some(glob => glob.match(fileName))) {
 			return {
 				file: callSite.getFileName(),
 				line: callSite.getLineNumber() - 1


### PR DESCRIPTION
Exclude filename -less stack call sites (such as internal JS functions) from glob matching.