### PR TITLE
fix: add compatibility for newer versions of VSCode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-jasmine-test-adapter",
-  "version": "1.8.1",
+  "version": "1.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-jasmine-test-adapter",
-      "version": "1.8.1",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "img/icon.png",
   "author": "Holger Benl <hbenl@evandor.de>",
   "publisher": "hbenl",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "license": "MIT",
   "homepage": "https://github.com/hbenl/vscode-jasmine-test-adapter",
   "repository": {

--- a/src/worker/loadTestsReporter.ts
+++ b/src/worker/loadTestsReporter.ts
@@ -5,44 +5,27 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 
 	private readonly rootSuite: TestSuiteInfo;
 	private readonly suiteStack: TestSuiteInfo[];
-	private currentFile: string | undefined;
 
 	private get currentSuite(): TestSuiteInfo {
 		return this.suiteStack[this.suiteStack.length - 1];
 	}
 
 	constructor(
-		private readonly done: (result: TestSuiteInfo) => void,
+		private readonly onDone: (result: TestSuiteInfo) => Promise<void>,
 		private readonly locations: Map<string, Location>
 	) {
 		this.rootSuite = {
 			type: 'suite',
 			id: 'root',
-			label: '',
+			label: 'root',
+			file: '.',
 			children: [],
 		};
 
 		this.suiteStack = [ this.rootSuite ];
-
-		// we use process on exit as jasmineDone may not be called
-		process.on('exit', () => {
-			this.emitLastSuite();
-		});
 	}
 
-	makeFileSuite(file: string): TestSuiteInfo {
-		return {
-			type: 'suite',
-			id: file,
-			file: file,
-			label: file,
-			children: [],
-			isFileSuite: true,
-		} as TestSuiteInfo
-	}
-
-	suiteStarted(result: jasmine.CustomReporterResult): void {
-
+	suiteStarted(result: jasmine.SuiteResult): void {
 		const suite: TestSuiteInfo = {
 			type: 'suite',
 			id: result.fullName,
@@ -52,20 +35,21 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 
 		const location = this.locations.get(result.id);
 		if (location) {
-			this.processCurrentLocation(location);
 			suite.file = location.file;
 			suite.line = location.line;
 		}
-
 		this.currentSuite.children.push(suite);
 		this.suiteStack.push(suite);
 	}
 
 	suiteDone() {
+		this.currentSuite.children.sort((a, b) => {
+			return a.label.toLocaleLowerCase() < b.label.toLocaleLowerCase() ? -1 : 1;
+		});
 		this.suiteStack.pop();
 	}
 
-	specStarted(result: jasmine.CustomReporterResult): void {
+	specStarted(result: jasmine.SpecResult): void {
 		const test: TestInfo = {
 			type: 'test',
 			id: result.fullName,
@@ -75,7 +59,6 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 
 		const location = this.locations.get(result.id);
 		if (location) {
-			this.processCurrentLocation(location);
 			test.line = location.line,
 			test.file = location.file
 		} else {
@@ -85,26 +68,7 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 		this.currentSuite.children.push(test);
 	}
 
-	// This method will add a file suite if we changed
-	// The current file we're currenlty processing and push it
-	// On to the stack
-	// It will also emit through this.done() the last file
-	// This way we emit one suite per file, which keeps things manageable
-	// and mall enought for IPC
-	private processCurrentLocation(location: Location) {
-		if (location.file != this.currentFile) {
-			const fileSuite = this.makeFileSuite(location.file);
-			this.emitLastSuite();
-			this.currentFile = location.file;
-			this.suiteStack.push(fileSuite);
-		}
-	}
-
-	private emitLastSuite() {
-		if (!this.currentFile) { return; }
-		const doneSuite = this.suiteStack.pop();
-		if (doneSuite) {
-			this.done(doneSuite);
-		}
+	jasmineDone(_: jasmine.JasmineDoneInfo, done: () => void): void | Promise<void> {
+		this.onDone(this.rootSuite).then(done);
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
   "include": [
     "src/main.ts",
     "src/worker/loadTests.ts",
-    "src/worker/runTests.ts"
+    "src/worker/runTests.ts",
   ]
 }


### PR DESCRIPTION
- Replaced per-file suite emission with a single JSON payload to streamline IPC
- Introduced ChunkData message format with 'start', 'data', and 'end' events
- Updated adapter to parse and use entire test suite structure from worker
- Removed `fileURLToPath` usage and `JasmineTestSuiteInfo` interface
- Refactored `loadTestsReporter` to build a single nested root suite
- Sorted child tests alphabetically by label in each suite
- Improved robustness of `sendMessage` with error handling

This fixes the Jasmine plugin for newer versions of VSCode. Tested on 1.99
closes https://github.com/hbenl/vscode-jasmine-test-adapter/issues/38