### PR TITLE
groupByDescribe feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Property                            | Description
 `jasmineExplorer.debuggerPort`      | The port for running the debug sessions (default: `9229`)
 `jasmineExplorer.breakOnFirstLine`  | Setting to `true` injects a breakpoint at the first line of your test, (default: `false`)
 `jasmineExplorer.debuggerSkipFiles` | An array of glob patterns for files to skip when debugging (default: `[]`)
+`jasmineExplorer.groupByDescribe`   | true|false, false by default, groups testcases heirarchically by describe field, instead of grouping them by file name, in test explorer panel
 `testExplorer.codeLens`             | Show a CodeLens above each test or suite for running or debugging the tests
 `testExplorer.gutterDecoration`     | Show the state of each test in the editor using Gutter Decorations
 `testExplorer.onStart`              | Retire or reset all test states whenever a test run is started

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-jasmine-test-adapter",
-  "version": "1.8.1",
+  "version": "1.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-jasmine-test-adapter",
-      "version": "1.8.1",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "img/icon.png",
   "author": "Holger Benl <hbenl@evandor.de>",
   "publisher": "hbenl",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "license": "MIT",
   "homepage": "https://github.com/hbenl/vscode-jasmine-test-adapter",
   "repository": {
@@ -151,7 +151,13 @@
           "description": "write diagnostic logs to the given file",
           "type": "string",
           "scope": "resource"
-        }
+        },
+        "jasmineExplorer.groupByDescribe": {
+          "description": "Group tests by describe blocks instead of file names",
+          "type": "boolean",
+          "default": false,
+          "scope": "resource"
+        }        
       }
     }
   }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -36,6 +36,7 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 
 	private config?: LoadedConfig;
 	private nodesById = new Map<string, TestSuiteInfo | TestInfo>();
+	private describeGroups = new Map<string, TestSuiteInfo>();
 
 	private runningTestProcess: ChildProcess | undefined;
 
@@ -72,7 +73,8 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 				configChange.affectsConfiguration('jasmineExplorer.env', this.workspaceFolder.uri) ||
 				configChange.affectsConfiguration('jasmineExplorer.nodePath', this.workspaceFolder.uri) ||
 				configChange.affectsConfiguration('jasmineExplorer.nodeArgv', this.workspaceFolder.uri) ||
-				configChange.affectsConfiguration('jasmineExplorer.jasminePath', this.workspaceFolder.uri)) {
+				configChange.affectsConfiguration('jasmineExplorer.jasminePath', this.workspaceFolder.uri) ||
+				configChange.affectsConfiguration('jasmineExplorer.groupByDescribe', this.workspaceFolder.uri)) {
 
 				this.log.info('Sending reload event');
 				this.config = undefined;
@@ -140,14 +142,20 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 
 		const suites: { [id: string]: TestSuiteInfo } = {};
 
-		let errorMessage;
+		// Clear describeGroups when grouping by describe
+		if (config.groupByDescribe) {
+			this.describeGroups.clear();
+		}
+
+		let errorMessage: string | undefined;
 
 		await new Promise<JasmineTestSuiteInfo | undefined>(resolve => {
 			const args = [
 				config.jasminePath,
 				config.configFilePath,
 				JSON.stringify(config.testFileGlobs.map(glob => glob.pattern)),
-				JSON.stringify(this.log.enabled)
+				JSON.stringify(this.log.enabled),
+				JSON.stringify(config.groupByDescribe)
 			];
 			this.stderr = Buffer.alloc(0);
 			const childProcess = fork(
@@ -164,10 +172,6 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 
 			this.pipeProcess(childProcess);
 
-			// The loader emits one suite per file, in order of running
-			// When running in random order, the same file may have multiple suites emitted
-			// This way the only thing we need to do is just to replace the name
-			// With a shorter one
 			childProcess.on('message', (message: string | JasmineTestSuiteInfo) => {
 
 				if (typeof message === 'string') {
@@ -177,20 +181,27 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 				} else {
 
 					if (this.log.enabled) this.log.info(`Received tests for ${message.file} from worker`);
-					let file = message.file!;
-					try {
-						file = fileURLToPath(file);
-					} catch {}
-					if (this.log.enabled) this.log.info(`spec dir ${config.specDir} file ${file}`);
-					let baseDir = config.specRealDir;
-					if (file.startsWith(config.specDir) && !file.startsWith(config.specRealDir)) {
-						baseDir = config.specDir;
-					} 
-					message.label = file.replace(baseDir, '').replace(/^\//, '');
-					if (suites[file]) {
-						suites[file].children = suites[file].children.concat(message.children);
+					
+					if (config.groupByDescribe) {
+						// When grouping by describe, we need to reorganize the suites
+						this.processMessageByDescribe(message, rootSuite);
 					} else {
-						suites[file] = message;
+						// Original file-based processing
+						let file = message.file!;
+						try {
+							file = fileURLToPath(file);
+						} catch {}
+						if (this.log.enabled) this.log.info(`spec dir ${config.specDir} file ${file}`);
+						let baseDir = config.specRealDir;
+						if (file.startsWith(config.specDir) && !file.startsWith(config.specRealDir)) {
+							baseDir = config.specDir;
+						} 
+						message.label = file.replace(baseDir, '').replace(/^\//, '');
+						if (suites[file]) {
+							suites[file].children = suites[file].children.concat(message.children);
+						} else {
+							suites[file] = message;
+						}
 					}
 				}
 			});
@@ -215,15 +226,26 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 			return s;
 		}
 
-		// Sort the suites by their filenames
-		Object.keys(suites).sort((a, b) => {
-			return a.toLocaleLowerCase() < b.toLocaleLowerCase() ? -1 : 1;
-		}).forEach((file) => {
-			try {
-				file = fileURLToPath(file);
-			} catch {}
-			rootSuite.children.push(sort(suites[file]));
-		});
+		if (config.groupByDescribe) {
+			// Sort describe groups alphabetically
+			const sortedGroups = Array.from(this.describeGroups.entries()).sort((a, b) => 
+				a[0].toLocaleLowerCase().localeCompare(b[0].toLocaleLowerCase())
+			);
+			
+			for (const [, group] of sortedGroups) {
+				rootSuite.children.push(sort(group));
+			}
+		} else {
+			// Original file-based sorting
+			Object.keys(suites).sort((a, b) => {
+				return a.toLocaleLowerCase() < b.toLocaleLowerCase() ? -1 : 1;
+			}).forEach((file) => {
+				try {
+					file = fileURLToPath(file);
+				} catch {}
+				rootSuite.children.push(sort(suites[file]));
+			});
+		}
 
 		this.nodesById.clear();
 		this.collectNodesById(rootSuite);
@@ -234,6 +256,89 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 			this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: rootSuite });
 		} else {
 			this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: undefined });
+		}
+	}
+
+	private processMessageByDescribe(message: JasmineTestSuiteInfo, rootSuite: TestSuiteInfo): void {
+		// Process each child in the message
+		for (const child of message.children) {
+			this.addToDescribeGroup(child, rootSuite, message.file!);
+		}
+	}
+
+	private addToDescribeGroup(node: TestSuiteInfo | TestInfo, rootSuite: TestSuiteInfo, file: string): void {
+		if (node.type === 'suite') {
+			const suite = node as TestSuiteInfo;
+			
+			// Get or create the describe group
+			let describeGroup = this.describeGroups.get(suite.label);
+			if (!describeGroup) {
+				describeGroup = {
+					type: 'suite',
+					id: `describe:${suite.label}`,
+					label: suite.label,
+					children: []
+				};
+				this.describeGroups.set(suite.label, describeGroup);
+				rootSuite.children.push(describeGroup);
+			}
+			
+			// Create a new suite with updated ID to avoid conflicts
+			const newSuite: TestSuiteInfo = {
+				type: 'suite',
+				id: suite.id,
+				label: suite.label,
+				file: suite.file || file,
+				line: suite.line,
+				children: []
+			};
+			
+			// Process children recursively
+			for (const child of suite.children) {
+				if (child.type === 'suite') {
+					// For nested describes, add them directly
+					newSuite.children.push(child);
+				} else {
+					// For tests, ensure they have file info
+					const test = child as TestInfo;
+					test.file = test.file || file;
+					newSuite.children.push(test);
+				}
+			}
+			
+			// Merge with existing describe group
+			this.mergeIntoDescribeGroup(describeGroup, newSuite);
+		} else {
+			// Test at root level (not in any describe)
+			let ungrouped = this.describeGroups.get('_ungrouped_');
+			if (!ungrouped) {
+				ungrouped = {
+					type: 'suite',
+					id: 'describe:_ungrouped_',
+					label: 'Tests',
+					children: []
+				};
+				this.describeGroups.set('_ungrouped_', ungrouped);
+				rootSuite.children.push(ungrouped);
+			}
+			const test = node as TestInfo;
+			test.file = test.file || file;
+			ungrouped.children.push(test);
+		}
+	}
+
+	private mergeIntoDescribeGroup(target: TestSuiteInfo, source: TestSuiteInfo): void {
+		// If this is the first time we see this describe, just add all children
+		if (target.children.length === 0) {
+			target.children = source.children;
+			target.file = source.file;
+			target.line = source.line;
+			return;
+		}
+		
+		// Otherwise, merge children
+		for (const child of source.children) {
+			target.children.push(child);
 		}
 	}
 
@@ -394,7 +499,7 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 	private pipeProcess(process: ChildProcess) {
 		const customStream = new stream.Writable();
 		customStream._write = (data, encoding, callback) => {
-			this.stderr = Buffer.concat([this.stderr, data]);
+			this.stderr = Buffer.concat([this.stderr!, data]);
 			this.channel.append(data.toString());
 			callback();
 		};
@@ -486,8 +591,9 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 		if (this.log.enabled) this.log.debug(`Using breakOnFirstLine: ${breakOnFirstLine}`);
 
 		const debuggerSkipFiles = adapterConfig.get<string[]>('debuggerSkipFiles') || [];
+		const groupByDescribe = adapterConfig.get<boolean>('groupByDescribe') || false;
 
-		return { cwd, configFilePath, specDir, specRealDir, testFileGlobs, env, nodePath, nodeArgv, jasminePath, debuggerPort, debuggerConfig, breakOnFirstLine, debuggerSkipFiles };
+		return { cwd, configFilePath, specDir, specRealDir, testFileGlobs, env, nodePath, nodeArgv, jasminePath, debuggerPort, debuggerConfig, breakOnFirstLine, debuggerSkipFiles, groupByDescribe };
 	}
 
 	private getConfigLog() {
@@ -580,6 +686,7 @@ interface LoadedConfig {
 	debuggerConfig: string | undefined;
 	breakOnFirstLine: boolean;
 	debuggerSkipFiles: string[];
+	groupByDescribe: boolean;
 }
 
 interface JasmineTestSuiteInfo extends TestSuiteInfo {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -270,44 +270,23 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 		if (node.type === 'suite') {
 			const suite = node as TestSuiteInfo;
 			
-			// Get or create the describe group
+			// Get or create the describe group at the root level
 			let describeGroup = this.describeGroups.get(suite.label);
 			if (!describeGroup) {
 				describeGroup = {
 					type: 'suite',
 					id: `describe:${suite.label}`,
 					label: suite.label,
-					children: []
+					children: [],
+					file: suite.file || file,
+					line: suite.line
 				};
 				this.describeGroups.set(suite.label, describeGroup);
 				rootSuite.children.push(describeGroup);
 			}
 			
-			// Create a new suite with updated ID to avoid conflicts
-			const newSuite: TestSuiteInfo = {
-				type: 'suite',
-				id: suite.id,
-				label: suite.label,
-				file: suite.file || file,
-				line: suite.line,
-				children: []
-			};
-			
-			// Process children recursively
-			for (const child of suite.children) {
-				if (child.type === 'suite') {
-					// For nested describes, add them directly
-					newSuite.children.push(child);
-				} else {
-					// For tests, ensure they have file info
-					const test = child as TestInfo;
-					test.file = test.file || file;
-					newSuite.children.push(test);
-				}
-			}
-			
-			// Merge with existing describe group
-			this.mergeIntoDescribeGroup(describeGroup, newSuite);
+			// Now we need to merge the suite's content into the describe group
+			this.mergeSuiteIntoGroup(describeGroup, suite, file);
 		} else {
 			// Test at root level (not in any describe)
 			let ungrouped = this.describeGroups.get('_ungrouped_');
@@ -327,18 +306,43 @@ export class JasmineAdapter implements TestAdapter, IDisposable {
 		}
 	}
 
-	private mergeIntoDescribeGroup(target: TestSuiteInfo, source: TestSuiteInfo): void {
-		// If this is the first time we see this describe, just add all children
-		if (target.children.length === 0) {
-			target.children = source.children;
-			target.file = source.file;
-			target.line = source.line;
-			return;
-		}
-		
-		// Otherwise, merge children
-		for (const child of source.children) {
-			target.children.push(child);
+	private mergeSuiteIntoGroup(targetGroup: TestSuiteInfo, sourceSuite: TestSuiteInfo, file: string): void {
+		// Process each child of the source suite
+		for (const child of sourceSuite.children) {
+			if (child.type === 'suite') {
+				// For nested suites, we need to find or create the matching child in the target
+				const childSuite = child as TestSuiteInfo;
+				let matchingChild: TestSuiteInfo | undefined;
+				
+				// Look for an existing child with the same label
+				for (const targetChild of targetGroup.children) {
+					if (targetChild.type === 'suite' && targetChild.label === childSuite.label) {
+						matchingChild = targetChild as TestSuiteInfo;
+						break;
+					}
+				}
+				
+				if (!matchingChild) {
+					// Create a new child suite
+					matchingChild = {
+						type: 'suite',
+						id: childSuite.id,
+						label: childSuite.label,
+						file: childSuite.file || file,
+						line: childSuite.line,
+						children: []
+					};
+					targetGroup.children.push(matchingChild);
+				}
+				
+				// Recursively merge the children
+				this.mergeSuiteIntoGroup(matchingChild, childSuite, file);
+			} else {
+				// For tests, just add them to the target group
+				const test = child as TestInfo;
+				test.file = test.file || file;
+				targetGroup.children.push(test);
+			}
 		}
 	}
 

--- a/src/worker/loadTests.ts
+++ b/src/worker/loadTests.ts
@@ -11,6 +11,7 @@ try {
 	const configFile = process.argv[3];
 	const testFileGlobs: string[] = JSON.parse(process.argv[4]);
 	logEnabled = <boolean>JSON.parse(process.argv[5]);
+	const groupByDescribe = process.argv[6] ? <boolean>JSON.parse(process.argv[6]) : false;
 
 	const Jasmine = require(jasminePath);
 	const jasmine = new Jasmine({});
@@ -27,7 +28,7 @@ try {
 	// Note that jasmine will start the tests asynchronously, so the reporter will still
 	// be added before the tests are run.
 	if (logEnabled) sendMessage('Creating and adding reporter');
-	jasmine.env.addReporter(new LoadTestsReporter(sendMessage, locations));
+	jasmine.env.addReporter(new LoadTestsReporter(sendMessage, locations, groupByDescribe));
 
 } catch (err) {
 	if (logEnabled) sendMessage(`Caught error ${util.inspect(err)}`);

--- a/src/worker/loadTestsReporter.ts
+++ b/src/worker/loadTestsReporter.ts
@@ -1,6 +1,11 @@
 import { TestSuiteInfo, TestInfo } from "vscode-test-adapter-api";
 import { Location } from "./patchJasmine";
 
+// Extend the TestSuiteInfo type to include our custom property
+interface ExtendedTestSuiteInfo extends TestSuiteInfo {
+	isFileSuite?: boolean;
+}
+
 export class LoadTestsReporter implements jasmine.CustomReporter {
 
 	private readonly rootSuite: TestSuiteInfo;
@@ -13,7 +18,8 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 
 	constructor(
 		private readonly done: (result: TestSuiteInfo) => void,
-		private readonly locations: Map<string, Location>
+		private readonly locations: Map<string, Location>,
+		private readonly groupByDescribe: boolean = false
 	) {
 		this.rootSuite = {
 			type: 'suite',
@@ -25,12 +31,12 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 		this.suiteStack = [ this.rootSuite ];
 
 		// we use process on exit as jasmineDone may not be called
-		process.on('exit', () => {
+		process.on('exit', () => {
 			this.emitLastSuite();
 		});
 	}
 
-	makeFileSuite(file: string): TestSuiteInfo {
+	makeFileSuite(file: string): ExtendedTestSuiteInfo {
 		return {
 			type: 'suite',
 			id: file,
@@ -38,11 +44,10 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 			label: file,
 			children: [],
 			isFileSuite: true,
-		} as TestSuiteInfo
+		};
 	}
 
 	suiteStarted(result: jasmine.CustomReporterResult): void {
-
 		const suite: TestSuiteInfo = {
 			type: 'suite',
 			id: result.fullName,
@@ -52,7 +57,16 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 
 		const location = this.locations.get(result.id);
 		if (location) {
-			this.processCurrentLocation(location);
+			// When grouping by describe, we still need to track files
+			// but we don't create file suites
+			if (!this.groupByDescribe) {
+				this.processCurrentLocation(location);
+			} else if (location.file !== this.currentFile) {
+				// For describe grouping, emit previous file's suites
+				this.emitLastSuite();
+				this.currentFile = location.file;
+				// Don't create a file suite, just track the file
+			}
 			suite.file = location.file;
 			suite.line = location.line;
 		}
@@ -75,9 +89,15 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 
 		const location = this.locations.get(result.id);
 		if (location) {
-			this.processCurrentLocation(location);
-			test.line = location.line,
-			test.file = location.file
+			if (!this.groupByDescribe) {
+				this.processCurrentLocation(location);
+			} else if (location.file !== this.currentFile) {
+				// For describe grouping, emit previous file's suites
+				this.emitLastSuite();
+				this.currentFile = location.file;
+			}
+			test.line = location.line;
+			test.file = location.file;
 		} else {
 			console.log('Could not find location for spec', result.fullName);
 		}
@@ -90,7 +110,7 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 	// On to the stack
 	// It will also emit through this.done() the last file
 	// This way we emit one suite per file, which keeps things manageable
-	// and mall enought for IPC
+	// and small enough for IPC
 	private processCurrentLocation(location: Location) {
 		if (location.file != this.currentFile) {
 			const fileSuite = this.makeFileSuite(location.file);
@@ -102,9 +122,27 @@ export class LoadTestsReporter implements jasmine.CustomReporter {
 
 	private emitLastSuite() {
 		if (!this.currentFile) { return; }
-		const doneSuite = this.suiteStack.pop();
-		if (doneSuite) {
-			this.done(doneSuite);
+		
+		if (this.groupByDescribe) {
+			// For describe grouping, emit the root suite with file info
+			if (this.rootSuite.children.length > 0) {
+				const fileInfo: ExtendedTestSuiteInfo = {
+					type: 'suite',
+					id: this.currentFile,
+					file: this.currentFile,
+					label: this.currentFile,
+					children: [...this.rootSuite.children],
+					isFileSuite: true
+				};
+				this.done(fileInfo);
+				this.rootSuite.children = [];
+			}
+		} else {
+			// Original file-based emission
+			const doneSuite = this.suiteStack.pop();
+			if (doneSuite) {
+				this.done(doneSuite);
+			}
 		}
 	}
 }


### PR DESCRIPTION
I added a feature which groups the testcases by describe in test explorer ui panel in the vs code side bar.

To enable the feature you need to add the following param in .vscode/settings.son file:

```
"jasmineExplorer.groupByDescribe": true
```

you can create hierarchical structures by embedding describes in in each-other:

File1.spec.js:

```
describe('checks', () => {

  describe('APIChecker', () => {

    ...
```
   
   
File2.spec.js:

```
describe('checks', () => {

  describe('LLMChecker', () => {
    let checker;
    ...
 ```
    